### PR TITLE
Fix shader display across all sections

### DIFF
--- a/src/components/ShaderBackground.jsx
+++ b/src/components/ShaderBackground.jsx
@@ -155,15 +155,22 @@ extend({ CPPNShaderMaterial });
 
 function ShaderPlane({ tint = '#0b1220' }) {
   const materialRef = useRef();
+  const meshRef = useRef();
   useFrame((state) => {
-    if (!materialRef.current) return;
-    materialRef.current.iTime = state.clock.elapsedTime;
-    const { width, height } = state.size;
-    materialRef.current.iResolution.set(width, height);
+    if (materialRef.current) {
+      materialRef.current.iTime = state.clock.elapsedTime;
+      const { width, height } = state.size;
+      materialRef.current.iResolution.set(width, height);
+    }
+    // Always scale the plane to the current viewport so it fills the canvas
+    if (meshRef.current) {
+      const { width: vw, height: vh } = state.viewport;
+      meshRef.current.scale.set(vw, vh, 1);
+    }
   });
   return (
-    <mesh position={[0, 0, -0.5]}>
-      <planeGeometry args={[4, 4]} />
+    <mesh ref={meshRef} position={[0, 0, -0.5]}>
+      <planeGeometry args={[1, 1]} />
       <cPPNShaderMaterial ref={materialRef} uTint={new THREE.Color(tint)} side={THREE.DoubleSide} />
     </mesh>
   );


### PR DESCRIPTION
Dynamically scale the shader background plane to the viewport dimensions to ensure it consistently covers the entire section.

---
<a href="https://cursor.com/background-agent?bcId=bc-0457843f-9ae5-4615-9f0d-d72077b5d429">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0457843f-9ae5-4615-9f0d-d72077b5d429">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

